### PR TITLE
Fix 'unused variable' error when HAVE_LIBFUSE && !HAVE_LIBSQLCIPHER

### DIFF
--- a/fuse_sqlfs.c
+++ b/fuse_sqlfs.c
@@ -31,6 +31,7 @@ int main(int argc, char **argv)
 /* get the password from stdin */
 #  define BUF_SIZE 8192
     char password[BUF_SIZE];
+    sqlfs_t *sqlfs = 0;
     char *p = fgets(password, BUF_SIZE, stdin);
     if (p)
     {


### PR DESCRIPTION
fuse_sqlfs.c: In function ‘main’:
fuse_sqlfs.c:27:14: error: unused variable ‘sqlfs’ [-Werror=unused-variable]
     sqlfs_t *sqlfs = 0;
              ^
cc1: all warnings being treated as errors

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>