### PR TITLE
Fix parallel build errors due to bad sqlfscat and sqlfsls dependencies

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,14 +13,14 @@ libsqlfs_1_0_la_LDFLAGS = -version-info 1:0:0
 
 bin_PROGRAMS = sqlfscat sqlfsls
 sqlfscat_SOURCES = sqlfscat.c
-sqlfscat_LDADD = -lpthread @SQLITE@ ./.libs/libsqlfs-1.0.la
+sqlfscat_LDADD = -lpthread @SQLITE@ ./libsqlfs-1.0.la
 sqlfsls_SOURCES = sqlfsls.cpp
-sqlfsls_LDADD = -lpthread @SQLITE@ ./.libs/libsqlfs-1.0.la
+sqlfsls_LDADD = -lpthread @SQLITE@ ./libsqlfs-1.0.la
 
 if WITH_LIBFUSE
 bin_PROGRAMS += fuse_sqlfs
 fuse_sqlfs_SOURCES = fuse_sqlfs.c
-fuse_sqlfs_LDADD = -lpthread @SQLITE@ @LIBFUSE@ ./.libs/libsqlfs-1.0.la
+fuse_sqlfs_LDADD = -lpthread @SQLITE@ @LIBFUSE@ ./libsqlfs-1.0.la
 endif
 
 pkgconfigdir = $(libdir)/pkgconfig

--- a/jenkins-build
+++ b/jenkins-build
@@ -13,7 +13,7 @@ fi
 # now run the build
 ./configure --with-fuse
 make clean
-make
+make -j4
 ls -1 *.c *.h tests/c*.c | sort | \
     cppcheck --enable=all --file-list=- --max-configs=50 -I/usr/include --xml \
     2> cppcheck-result.xml


### PR DESCRIPTION
 $ ./autogen.sh
 $ ./configure
 $ make -j9
 [...]
 make[1]: *** No rule to make target '.libs/libsqlfs-1.0.la', needed by 'sqlfscat'.  Stop.
 make[1]: *** Waiting for unfinished jobs....

jenkins-build is updated to use 'make -j4' when building the library
and the tests, so that parallel build is properly validated.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>