### PR TITLE
Fix issue with podspec on CocoaPods 1.0+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ tests/fuse_test
 #
 # emacs!
 *~
+.DS_Store

--- a/libsqlfs.podspec
+++ b/libsqlfs.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.default_subspec = 'standard'
 
   s.subspec 'common' do |ss|
-    ss.source_files = 'sqlfs.{h,m}', 'sqlfs_internal.h'
+    ss.source_files = 'sqlfs.{h,c}', 'sqlfs_internal.h'
   end
 
   # use a builtin version of sqlite3

--- a/libsqlfs.podspec
+++ b/libsqlfs.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "libsqlfs"
-  s.version          = "1.3"
+  s.version          = "1.3.0.1"
   s.summary          = "Library that implements a POSIX style filesystem on top of an SQLite database"
   s.description      = <<-DESC
                         The libsqlfs library implements a POSIX style file system on top of an
@@ -16,15 +16,17 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/guardianproject/libsqlfs.git", :tag => "v1.3" }
   s.social_media_url = 'https://twitter.com/guardianproject'
 
-  s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.8'
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.9'
+  s.tvos.deployment_target = '9.0'
+  s.watchos.deployment_target = '2.0'
 
   s.requires_arc = true
 
   s.default_subspec = 'standard'
 
   s.subspec 'common' do |ss|
-    ss.source_files = 'sqlfs_internal.h', 'sqlfs.c', 'sqlfs.h'
+    ss.source_files = 'sqlfs.{h,m}', 'sqlfs_internal.h'
   end
 
   # use a builtin version of sqlite3
@@ -35,7 +37,7 @@ Pod::Spec.new do |s|
 
   # use SQLCipher and enable -DHAVE_LIBSQLCIPHER flag
   s.subspec 'SQLCipher' do |ss|
-    ss.dependency 'SQLCipher/fts'
+    ss.dependency 'SQLCipher', '~> 3.4.0'
     ss.dependency 'libsqlfs/common'
     ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DHAVE_LIBSQLCIPHER -DSQLITE_HAS_CODEC' }
   end

--- a/libsqlfs.podspec
+++ b/libsqlfs.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "libsqlfs"
-  s.version          = "1.3.0.1"
+  s.version          = "1.3.2"
   s.summary          = "Library that implements a POSIX style filesystem on top of an SQLite database"
   s.description      = <<-DESC
                         The libsqlfs library implements a POSIX style file system on top of an

--- a/sqlfs.c
+++ b/sqlfs.c
@@ -56,6 +56,20 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # include "sqlite3.h"
 #endif
 
+struct sqlfs_t
+{
+    sqlite3 *db;
+    int transaction_level;
+    int in_transaction;
+    mode_t default_mode;
+    
+    sqlite3_stmt *stmts[200];
+#ifndef HAVE_LIBFUSE
+    uid_t uid;
+    gid_t gid;
+#endif
+};
+
 
 #define INDEX 0
 

--- a/sqlfs_internal.h
+++ b/sqlfs_internal.h
@@ -36,12 +36,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <errno.h>
 #include <utime.h>
 
-#ifdef HAVE_LIBSQLCIPHER
-#include "sqlcipher/sqlite3.h"
-#else
-#include "sqlite3.h"
-#endif
-
 #define TYPE_NULL "null"
 #define TYPE_DIR "dir"
 #define TYPE_INT "int"
@@ -52,22 +46,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #define TYPE_LIST "list"
 #define TYPE_BLOB "blob"
 
-
-
-typedef struct
-{
-    sqlite3 *db;
-    int transaction_level;
-    int in_transaction;
-    mode_t default_mode;
-
-    sqlite3_stmt *stmts[200];
-#ifndef HAVE_LIBFUSE
-    uid_t uid;
-    gid_t gid;
-#endif
-}
-sqlfs_t;
+typedef struct sqlfs_t sqlfs_t;
 
 typedef struct
 {


### PR DESCRIPTION
The latest version of CocoaPods has problems with the ordering of the header includes, specifically that 'sqlfs_internal.h' must be included after sqlfs.h.
