### PR TITLE
Fix tests after cocoapods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y libfuse-dev libsqlite3-dev cppcheck
+  - sudo apt-get install -y libfuse-dev libsqlcipher-dev cppcheck
 
 language: c
 

--- a/tests/common.c
+++ b/tests/common.c
@@ -26,9 +26,29 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <sys/time.h>
 #include "sqlfs.h"
 
+#ifdef HAVE_LIBSQLCIPHER
+# include "sqlcipher/sqlite3.h"
+#else
+# include "sqlite3.h"
+#endif
+
 #define BLOCK_SIZE 8192
 
 char *data = "this is a string";
+
+struct sqlfs_t
+{
+    sqlite3 *db;
+    int transaction_level;
+    int in_transaction;
+    mode_t default_mode;
+    
+    sqlite3_stmt *stmts[200];
+#ifndef HAVE_LIBFUSE
+    uid_t uid;
+    gid_t gid;
+#endif
+};
 
 /* support functions -------------------------------------------------------- */
 


### PR DESCRIPTION
The Travis-CI tests were only running with SQLite3 and not SQLCipher, so the encryption tests were not running.  So in #11 commit a4b1944, it broke the tests that use a key/password.  This fixes that and switches the Travis-CI tests to be based on SQLCipher.