### PR TITLE
Use SQLCipher >= 3.4.0 in podspec to support 4.0.0 release

### DIFF
--- a/libsqlfs.podspec
+++ b/libsqlfs.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
 
   # use SQLCipher and enable -DHAVE_LIBSQLCIPHER flag
   s.subspec 'SQLCipher' do |ss|
-    ss.dependency 'SQLCipher', '~> 3.4.0'
+    ss.dependency 'SQLCipher', '>= 3.4.0'
     ss.dependency 'libsqlfs/common'
     ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DHAVE_LIBSQLCIPHER -DSQLITE_HAS_CODEC' }
   end


### PR DESCRIPTION
SQLCipher 4.0.0 has been released: https://github.com/sqlcipher/sqlcipher/blob/master/CHANGELOG.md#400---2018-11-30