### PR TITLE
Revert "Fix check_parent_write() when !HAVE_LIBFUSE"

### DIFF
--- a/jenkins-build
+++ b/jenkins-build
@@ -18,8 +18,3 @@ ls -1 *.c *.h tests/c*.c | sort | \
     cppcheck --enable=all --file-list=- --max-configs=50 -I/usr/include --xml \
     2> cppcheck-result.xml
 make check V=1
-make clean
-./configure --without-fuse
-make clean
-make -j4
-make check V=1

--- a/sqlfs.c
+++ b/sqlfs.c
@@ -1709,7 +1709,20 @@ static int check_parent_write(sqlfs_t *sqlfs, const char *path)
     begin_transaction(get_sqlfs(sqlfs));
     r = get_parent_path(path, ppath);
     if (r == SQLITE_OK)
+    {
         result = (sqlfs_proc_access(sqlfs, (ppath), W_OK | X_OK));
+#ifndef HAVE_LIBFUSE
+        /* libfuse seems to enforce that the parent directory before getting
+         * here, but without libfuse, we need to do it manually */
+        if (result == -ENOENT)
+        {
+            result = check_parent_write(sqlfs, ppath);
+            if (result == 0)
+                ensure_existence(sqlfs, ppath, TYPE_DIR);
+            result = (sqlfs_proc_access(sqlfs, (ppath), W_OK | X_OK));
+        }
+#endif
+    }
     commit_transaction(get_sqlfs(sqlfs), 1);
     return result;
 }


### PR DESCRIPTION
This reverts commit 6d57386164dc2c393cf01e59a76f6be223c8b34f.

This commit causes a regression in ChatSecure, and makes libsqlfs unusable.