### PR TITLE
Stick with backwards compat

### DIFF
--- a/sqlfs.c
+++ b/sqlfs.c
@@ -3260,6 +3260,7 @@ static void * sqlfs_t_init(const char *db_file, const char *password)
             show_msg(stderr, "Opening the database with provided key/password failed!\n");
             return 0;
         }
+        sqlite3_exec(sql_fs->db, "PRAGMA cipher_compatibility = 3;", NULL, NULL, NULL);
         sqlite3_exec(sql_fs->db, "PRAGMA cipher_page_size = 8192;", NULL, NULL, NULL);
     }
     else


### PR DESCRIPTION
I couldn't make the cipher migration for SQLCipher 4 to work with an existing larger IOCipher instance. The easier solution for now is to set the v3 compatibility mode.